### PR TITLE
Add the concept of to-perl

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -44,6 +44,20 @@ jobs:
           since-perl: 5.36
           with-devel: true
 
+  since-524-to-532:
+    runs-on: ubuntu-latest
+    name: 'since 5.24 to 5.32'
+    outputs:
+      perl-versions: ${{ steps.action.outputs.perl-versions }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: "uses perl-versions"
+        id: action
+        uses: ./
+        with:
+          since-perl: "5.24"
+          to-perl: "5.32"
+
   test-matrix:
     runs-on: ubuntu-latest
     needs:
@@ -75,6 +89,7 @@ jobs:
       - since-v520
       - since-520
       - since-536-with-devel
+      - since-524-to-532
     runs-on: ubuntu-latest
     steps:
 
@@ -89,3 +104,7 @@ jobs:
       - name: "Testing since-536-with-devel"
         run: |
           [[ '${{ needs.since-536-with-devel.outputs.perl-versions }}' == '["5.36","5.38","5.40","5.42","devel"]' ]] && echo "ok"
+
+      - name: "Testing since-524-to-532"
+        run: |
+          [[ '${{ needs.since-524-to-532.outputs.perl-versions }}' == '["5.24","5.26","5.28","5.30","5.32"]' ]] && echo "ok"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ Returns perl versions since this (including).
 
 When unknown version is provided, returns empty list.
 
+### to-perl
+
+Optional parameter.
+
+When set, returns perl versions up to this version (including this version).
+Can be combined with `since-perl` to get a specific range of versions.
+
+When not set, returns all versions from `since-perl` onwards.
+
 ### with-devel
 
 Default: `false`
@@ -37,6 +46,7 @@ jobs:
         uses: perl-actions/perl-versions@v1
         with:
           since-perl: v5.20
+          to-perl: v5.36
           with-devel: false
 
   ##

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: "List all Perl versions since this (including this). Example: 5.10"
     type: string
     required: true
+  to-perl:
+    description: "List all Perl versions up to this (including this). Example: 5.30"
+    type: string
+    required: false
   with-devel:
     description: "Whether to include also 'devel' Perl"
     type: boolean

--- a/dist/index.js
+++ b/dist/index.js
@@ -30267,6 +30267,8 @@ let available = [
 
 try {
     const since_perl = semver.coerce(core.getInput('since-perl'));
+    const to_perl_input = core.getInput('to-perl');
+    const to_perl = to_perl_input ? semver.coerce(to_perl_input) : null;
     const with_devel = core.getInput('with-devel') == "true";
 
     let filtered = available.filter(
@@ -30274,7 +30276,10 @@ try {
             if (item == "devel") {
                 return with_devel;
             }
-            return semver.gte(semver.coerce(item), since_perl);
+            const version = semver.coerce(item);
+            const meetsLowerBound = semver.gte(version, since_perl);
+            const meetsUpperBound = !to_perl || semver.lte(version, to_perl);
+            return meetsLowerBound && meetsUpperBound;
         }
     );
 

--- a/index.js
+++ b/index.js
@@ -12,6 +12,8 @@ let available = [
 
 try {
     const since_perl = semver.coerce(core.getInput('since-perl'));
+    const to_perl_input = core.getInput('to-perl');
+    const to_perl = to_perl_input ? semver.coerce(to_perl_input) : null;
     const with_devel = core.getInput('with-devel') == "true";
 
     let filtered = available.filter(
@@ -19,7 +21,10 @@ try {
             if (item == "devel") {
                 return with_devel;
             }
-            return semver.gte(semver.coerce(item), since_perl);
+            const version = semver.coerce(item);
+            const meetsLowerBound = semver.gte(version, since_perl);
+            const meetsUpperBound = !to_perl || semver.lte(version, to_perl);
+            return meetsLowerBound && meetsUpperBound;
         }
     );
 


### PR DESCRIPTION
Similar than `since-perl` this is adding
the notion of `to-perl` so we can limit the list
of Perl versions we want to use.

This could be useful for docker-perl-tester where buster is not used anymore to build recent images.