### PR TITLE
Rename parameter `to-perl` to `until-perl`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ inputs:
     description: "List all Perl versions since this (including this). Example: 5.10"
     type: string
     required: true
-  to-perl:
+  until-perl:
     description: "List all Perl versions up to this (including this). Example: 5.30"
     type: string
     required: false

--- a/index.js
+++ b/index.js
@@ -12,8 +12,8 @@ let available = [
 
 try {
     const since_perl = semver.coerce(core.getInput('since-perl'));
-    const to_perl_input = core.getInput('to-perl');
-    const to_perl = to_perl_input ? semver.coerce(to_perl_input) : null;
+    const until_perl_input = core.getInput('until-perl');
+    const until_perl = until_perl_input ? semver.coerce(until_perl_input) : null;
     const with_devel = core.getInput('with-devel') == "true";
 
     let filtered = available.filter(
@@ -23,7 +23,7 @@ try {
             }
             const version = semver.coerce(item);
             const meetsLowerBound = semver.gte(version, since_perl);
-            const meetsUpperBound = !to_perl || semver.lte(version, to_perl);
+            const meetsUpperBound = !until_perl || semver.lte(version, until_perl);
             return meetsLowerBound && meetsUpperBound;
         }
     );


### PR DESCRIPTION
# action changes
- word `until` matches better with `since`

# workflow changes
- improve provide shared workflow to accept all action parameters
- improve `check` workflow to use matrix approach
- in order to make this action primary source of actual list of perl versions for other workflows it should not use artifacts provided by other. Chicken-egg problem.
