### PR TITLE
Rename `to-perl` to `until-perl`

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,108 +3,66 @@ name: "Check Workflow"
 on: [push, pull_request]
 
 jobs:
-
-  since-v520:
+  test-action:
     runs-on: ubuntu-latest
-    name: 'since v5.20'
-    outputs:
-      perl-versions: ${{ steps.action.outputs.perl-versions }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: "uses perl-versions"
-        id: action
-        uses: ./
-        with:
-          since-perl: v5.20
-
-  since-520:
-    runs-on: ubuntu-latest
-    name: 'since 5.20'
-    outputs:
-      perl-versions: ${{ steps.action.outputs.perl-versions }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: "uses perl-versions"
-        id: action
-        uses: ./
-        with:
-          since-perl: "5.20"
-
-  since-536-with-devel:
-    runs-on: ubuntu-latest
-    name: 'since 5.36 with devel'
-    outputs:
-      perl-versions: ${{ steps.action.outputs.perl-versions }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: "uses perl-versions"
-        id: action
-        uses: ./
-        with:
-          since-perl: 5.36
-          with-devel: true
-
-  since-524-to-532:
-    runs-on: ubuntu-latest
-    name: 'since 5.24 to 5.32'
-    outputs:
-      perl-versions: ${{ steps.action.outputs.perl-versions }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: "uses perl-versions"
-        id: action
-        uses: ./
-        with:
-          since-perl: "5.24"
-          to-perl: "5.32"
-
-  test-matrix:
-    runs-on: ubuntu-latest
-    needs:
-      - since-536-with-devel
     strategy:
-      fail-fast: false
       matrix:
-        perl-versions: ${{ fromJson (needs.since-536-with-devel.outputs.perl-versions) }}
-    steps:
-      - run: echo "Hello"
+        include:
+          - job-id:     since-v520
+            name:       "Since v5.20"
+            since-perl: "v5.20"
+            expected:   '["5.20","5.22","5.24","5.26","5.28","5.30","5.32","5.34","5.36","5.38","5.40","5.42"]'
 
-  perl-tester:
-    runs-on: ubuntu-latest
-    needs:
-      - since-536-with-devel
-    name: "Perl ${{ matrix.perl-version }}"
-    strategy:
-      fail-fast: false
-      matrix:
-        perl-version: ${{ fromJson (needs.since-536-with-devel.outputs.perl-versions) }}
-    container:
-      image: perldocker/perl-tester:${{ matrix.perl-version }}
+          - job-id:     since-520
+            name:       "Since 5.20"
+            since-perl: "5.20"
+            expected:   '["5.20","5.22","5.24","5.26","5.28","5.30","5.32","5.34","5.36","5.38","5.40","5.42"]'
+
+          - job-id:     since-536-with-devel
+            name:       "Since 5.36 with devel"
+            since-perl: "5.36"
+            with-devel: "true"
+            expected:   '["5.36","5.38","5.40","5.42","devel"]'
+
+          - job-id:     since-524-to-532
+            name:       "Since 5.24 until 5.32"
+            since-perl: "5.24"
+            until-perl: "5.32"
+            expected:   '["5.24","5.26","5.28","5.30","5.32"]'
+
+          - job-id:     with-devel-and-until
+            name:       "With devel and until-perl"
+            since-perl: "5.36"
+            until-perl: "5.40"
+            with-devel: "true"
+            expected:   '["5.36","5.38","5.40","devel"]'
+
+          - job-id:     single-version
+            name:       "Single version"
+            since-perl: "5.32"
+            until-perl: "5.32"
+            expected:   '["5.32"]'
+
+          - job-id:     oldest-supported
+            name:       "Oldest supported version is 5.8"
+            since-perl: "5.6"
+            until-perl: "5.14"
+            expected:   '["5.8","5.10","5.12","5.14"]'
+
     steps:
       - uses: actions/checkout@v4
-      - run: perl -V
 
-  check:
-    needs:
-      - since-v520
-      - since-520
-      - since-536-with-devel
-      - since-524-to-532
-    runs-on: ubuntu-latest
-    steps:
+      - name: "Call action - ${{ matrix.name }}"
+        id: call-action
+        uses: ./
+        with:
+          since-perl: ${{ matrix.since-perl }}
+          until-perl: ${{ matrix.until-perl || null }}
+          with-devel: ${{ matrix.with-devel || null }}
 
-      - name: "Testing since-v520"
-        run: |
-          [[ '${{ needs.since-v520.outputs.perl-versions }}' == '["5.20","5.22","5.24","5.26","5.28","5.30","5.32","5.34","5.36","5.38","5.40","5.42"]' ]] && echo "ok"
-
-      - name: "Testing since-520"
-        run: |
-          [[ '${{ needs.since-520.outputs.perl-versions }}' == '["5.20","5.22","5.24","5.26","5.28","5.30","5.32","5.34","5.36","5.38","5.40","5.42"]' ]] && echo "ok"
-
-      - name: "Testing since-536-with-devel"
-        run: |
-          [[ '${{ needs.since-536-with-devel.outputs.perl-versions }}' == '["5.36","5.38","5.40","5.42","devel"]' ]] && echo "ok"
-
-      - name: "Testing since-524-to-532"
-        run: |
-          [[ '${{ needs.since-524-to-532.outputs.perl-versions }}' == '["5.24","5.26","5.28","5.30","5.32"]' ]] && echo "ok"
+      - name: Validate output - ${{ matrix.name }}
+        uses: prompt/actions-assert@v4
+        with:
+          assertion: npm://@assertions/is-equal:v1
+          actual:    ${{ steps.call-action.outputs.perl-versions }}
+          expected:  ${{ matrix.expected }}

--- a/.github/workflows/perl-versions.yml
+++ b/.github/workflows/perl-versions.yml
@@ -8,6 +8,15 @@ on:
         type: string
         required: true
         default: "5.10"
+      until-perl:
+        description: "List all Perl versions up to this (including this). Example: 5.30"
+        type: string
+        required: false
+      with-devel:
+        description: "Whether to include also 'devel' Perl"
+        type: boolean
+        required: false
+        default: false
     outputs:
       perl-versions:
         value: ${{ jobs.perl-versions.outputs.perl-versions }}
@@ -24,4 +33,6 @@ jobs:
         uses: perl-actions/perl-versions@main
         with:
           since-perl: ${{ inputs.since-perl }}
+          until-perl: ${{ inputs.until-perl || null }}
+          with-devel: ${{ inputs.with-devel || null }}
 

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ inputs:
     description: "List all Perl versions since this (including this). Example: 5.10"
     type: string
     required: true
-  to-perl:
+  until-perl:
     description: "List all Perl versions up to this (including this). Example: 5.30"
     type: string
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -30267,8 +30267,8 @@ let available = [
 
 try {
     const since_perl = semver.coerce(core.getInput('since-perl'));
-    const to_perl_input = core.getInput('to-perl');
-    const to_perl = to_perl_input ? semver.coerce(to_perl_input) : null;
+    const until_perl_input = core.getInput('until-perl');
+    const until_perl = until_perl_input ? semver.coerce(until_perl_input) : null;
     const with_devel = core.getInput('with-devel') == "true";
 
     let filtered = available.filter(
@@ -30278,7 +30278,7 @@ try {
             }
             const version = semver.coerce(item);
             const meetsLowerBound = semver.gte(version, since_perl);
-            const meetsUpperBound = !to_perl || semver.lte(version, to_perl);
+            const meetsUpperBound = !until_perl || semver.lte(version, until_perl);
             return meetsLowerBound && meetsUpperBound;
         }
     );

--- a/dist/index.js
+++ b/dist/index.js
@@ -30265,10 +30265,14 @@ let available = [
     "devel",
 ];
 
+function parse_input_version (input_name) {
+    // semver.coerce() returns null for both empty string and null inputs
+    return semver.coerce (core.getInput (input_name));
+}
+
 try {
-    const since_perl = semver.coerce(core.getInput('since-perl'));
-    const until_perl_input = core.getInput('until-perl');
-    const until_perl = until_perl_input ? semver.coerce(until_perl_input) : null;
+    const since_perl = parse_input_version ('since-perl');
+    const until_perl = parse_input_version ('until-perl');
     const with_devel = core.getInput('with-devel') == "true";
 
     let filtered = available.filter(

--- a/index.js
+++ b/index.js
@@ -12,8 +12,8 @@ let available = [
 
 try {
     const since_perl = semver.coerce(core.getInput('since-perl'));
-    const to_perl_input = core.getInput('to-perl');
-    const to_perl = to_perl_input ? semver.coerce(to_perl_input) : null;
+    const until_perl_input = core.getInput('until-perl');
+    const until_perl = until_perl_input ? semver.coerce(until_perl_input) : null;
     const with_devel = core.getInput('with-devel') == "true";
 
     let filtered = available.filter(
@@ -23,7 +23,7 @@ try {
             }
             const version = semver.coerce(item);
             const meetsLowerBound = semver.gte(version, since_perl);
-            const meetsUpperBound = !to_perl || semver.lte(version, to_perl);
+            const meetsUpperBound = !until_perl || semver.lte(version, until_perl);
             return meetsLowerBound && meetsUpperBound;
         }
     );

--- a/index.js
+++ b/index.js
@@ -10,10 +10,14 @@ let available = [
     "devel",
 ];
 
+function parse_input_version (input_name) {
+    // semver.coerce() returns null for both empty string and null inputs
+    return semver.coerce (core.getInput (input_name));
+}
+
 try {
-    const since_perl = semver.coerce(core.getInput('since-perl'));
-    const until_perl_input = core.getInput('until-perl');
-    const until_perl = until_perl_input ? semver.coerce(until_perl_input) : null;
+    const since_perl = parse_input_version ('since-perl');
+    const until_perl = parse_input_version ('until-perl');
     const with_devel = core.getInput('with-devel') == "true";
 
     let filtered = available.filter(


### PR DESCRIPTION
# action changes
- word `until` matches better with `since`

# workflow changes
- improve provide shared workflow to accept all action parameters
- improve `check` workflow to use matrix approach
- in order to make this action primary source of actual list of perl versions for other workflows it should not use artifacts provided by other. Chicken-egg problem.